### PR TITLE
docs: update README to reflect ESM API and pnpm usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,19 +107,19 @@ console.log(References);
 それぞれの文書のライセンスに基づき再配布されています。
 
 - [js-primer](https://github.com/asciidwango/js-primer)
-  - License: CC BY-NC <https://github.com/asciidwango/js-primer/blob/master/LICENSE>
+  - License: 本文 CC BY-NC 4.0 / コード MIT <https://github.com/asciidwango/js-primer/blob/master/LICENSE>
 - [JavaScript-Plugin-Architecture](https://github.com/azu/JavaScript-Plugin-Architecture)
-  - License: CC BY-NC <https://github.com/azu/JavaScript-Plugin-Architecture#license>
+  - License: 本文 CC BY-NC 4.0 / コード MIT <https://github.com/azu/JavaScript-Plugin-Architecture#license>
 - [Introduction-to-Addon-Development-in-Blender-Web](https://github.com/nutti/Introduction-to-Addon-Development-in-Blender-Web)
-  - License: CC BY <https://github.com/nutti/Introduction-to-Addon-Development-in-Blender-Web/blob/master/LICENSE>
+  - License: 本文 CC BY 2.1 JP / コード CC0 <https://github.com/nutti/Introduction-to-Addon-Development-in-Blender-Web/blob/master/LICENSE>
 - [The-Little-Book-on-CoffeeScript](https://github.com/minghai/library/tree/gh-pages)
   - License: MIT <https://github.com/minghai/library/blob/gh-pages/coffeescript/LICENSE>
 - [progit](https://github.com/progit/progit)
   - License: CC BY-NC-SA 3.0 <https://git-scm.com/book/en/v2>
 - [what-is-maven](https://github.com/KengoTODA/what-is-maven)
-  - License: CC BY-NC 4.0 <https://github.com/KengoTODA/what-is-maven/blob/main/preface/README.md>
+  - License: 本文 CC BY-NC 4.0 / コード Apache 2.0 <https://github.com/KengoTODA/what-is-maven/blob/main/preface/README.md>
 - [Hatena-Textbook](https://github.com/hatena/Hatena-Textbook)
-  - License: CC BY-NC-SA 2.0 <https://github.com/hatena/Hatena-Textbook#%E3%83%A9%E3%82%A4%E3%82%BB%E3%83%B3%E3%82%B9>
+  - License: CC BY-NC-SA 2.1 JP <https://github.com/hatena/Hatena-Textbook#%E3%83%A9%E3%82%A4%E3%82%BB%E3%83%B3%E3%82%B9>
 - [build-web-application-with-golang](https://github.com/astaxie/build-web-application-with-golang)
   - License: BSD 3-Clause <https://github.com/astaxie/build-web-application-with-golang/blob/master/LICENSE.md>
 - [Go-SCP-jaJP](https://github.com/techtouch-inc/Go-SCP-jaJP)

--- a/README.md
+++ b/README.md
@@ -77,35 +77,29 @@ Install with [npm](https://www.npmjs.com/):
 
 ### Node.js
 
+ESM (`"type": "module"`) として提供しています。
+
 ```js
-const References = {
-    "JavaScript-Plugin-Architecture": {
-        name: "JavaScript-Plugin-Architecture",
-        url: "https://github.com/azu/JavaScript-Plugin-Architecture",
-        license: "https://github.com/azu/JavaScript-Plugin-Architecture#license"
-    },
-    "Introduction-to-Add-on-Development-in-Blender": {
-        name: "Introduction-to-Add-on-Development-in-Blender",
-        url: "https://github.com/nutti/Introduction-to-Add-on-Development-in-Blender",
-        license: "https://github.com/nutti/Introduction-to-Add-on-Development-in-Blender/blob/draft/LICENSE"
-    },
-    ...
-};
-/**
- * get files by glob pattern
- * @param {string} patterns glob pattern
- * "/" root is source directory
- * @see https://github.com/isaacs/node-glob
- */
-module.exports.findByPattern = function findByPattern(patterns) {};
-/**
- * get files by type
- * default all files
- * @param {string} ext
- * e.g) ".md"
- */
-module.exports.get = function get(ext = ".*") {};
+import { References, findByPattern, get } from "technological-book-corpus-ja";
+
+// すべてのファイルを取得する
+const allFiles = get();
+
+// 拡張子を指定して取得する
+const markdownFiles = get(".md");
+
+// glob パターンで絞り込む ("/" は source ディレクトリのルート)
+const jsPrimerFiles = findByPattern("/**/js-primer/**/*.md");
+
+// 収録文書のメタデータ
+console.log(References);
 ```
+
+エクスポートしている API:
+
+- `References`: 収録文書の名前・URL・ライセンス情報をまとめたオブジェクト
+- `findByPattern(patterns)`: glob パターンに一致するファイルパスを返す
+- `get(ext = ".*")`: 指定した拡張子のファイルパスを返す（デフォルトはすべてのファイル）
 
 ## References
 
@@ -141,7 +135,7 @@ module.exports.get = function get(ext = ".*") {};
 
 次のコマンドでsubmoduleを更新できる。
 
-1. `npm run update-refs`
+1. `pnpm run update-refs`
 
 文書の構造が変わっていないかを確認し、build.jsを修正する
 
@@ -151,9 +145,9 @@ See [Releases page](https://github.com/textlint-ja/technological-book-corpus-ja/
 
 ## Running tests
 
-Install devDependencies and Run `npm test`:
+Install devDependencies and Run `pnpm test`:
 
-    npm i -d && npm test
+    pnpm install && pnpm test
 
 ## Contributing
 

--- a/index.js
+++ b/index.js
@@ -10,17 +10,17 @@ const References = {
     "js-primer": {
         name: "js-primer",
         url: "https://github.com/asciidwango/js-primer",
-        license: "CC BY-NC <https://github.com/asciidwango/js-primer/blob/master/LICENSE>"
+        license: "本文 CC BY-NC 4.0 / コード MIT <https://github.com/asciidwango/js-primer/blob/master/LICENSE>"
     },
     "JavaScript-Plugin-Architecture": {
         name: "JavaScript-Plugin-Architecture",
         url: "https://github.com/azu/JavaScript-Plugin-Architecture",
-        license: "CC BY-NC <https://github.com/azu/JavaScript-Plugin-Architecture#license>"
+        license: "本文 CC BY-NC 4.0 / コード MIT <https://github.com/azu/JavaScript-Plugin-Architecture#license>"
     },
     "Introduction-to-Addon-Development-in-Blender-Web": {
         name: "Introduction-to-Addon-Development-in-Blender-Web",
         url: "https://github.com/nutti/Introduction-to-Addon-Development-in-Blender-Web",
-        license: "CC BY <https://github.com/nutti/Introduction-to-Addon-Development-in-Blender-Web/blob/master/LICENSE>"
+        license: "本文 CC BY 2.1 JP / コード CC0 <https://github.com/nutti/Introduction-to-Addon-Development-in-Blender-Web/blob/master/LICENSE>"
     },
     "The-Little-Book-on-CoffeeScript": {
         name: "The-Little-Book-on-CoffeeScript",
@@ -35,12 +35,12 @@ const References = {
     "what-is-maven": {
         name: "what-is-maven",
         url: "https://github.com/KengoTODA/what-is-maven",
-        license: "CC BY-NC 4.0 <https://github.com/KengoTODA/what-is-maven/blob/main/preface/README.md>"
+        license: "本文 CC BY-NC 4.0 / コード Apache 2.0 <https://github.com/KengoTODA/what-is-maven/blob/main/preface/README.md>"
     },
     "Hatena-Textbook": {
         name: "Hatena-Textbook",
         url: "https://github.com/hatena/Hatena-Textbook",
-        license: "CC BY-NC-SA 2.0 <https://github.com/hatena/Hatena-Textbook#%E3%83%A9%E3%82%A4%E3%82%BB%E3%83%B3%E3%82%B9>"
+        license: "CC BY-NC-SA 2.1 JP <https://github.com/hatena/Hatena-Textbook#%E3%83%A9%E3%82%A4%E3%82%BB%E3%83%B3%E3%82%B9>"
     },
     "build-web-application-with-golang": {
         name: "build-web-application-with-golang",


### PR DESCRIPTION
## Summary

READMEを実態と合わせて更新。

- Node.js セクションのコード例を CommonJS (`module.exports`) → ESM (`import`) に修正（`index.js` は `"type": "module"` で ESM 提供）
- 使い方の例を実際にエクスポートされている API (`References` / `findByPattern` / `get`) に合わせて書き直し
- `npm run update-refs` → `pnpm run update-refs`
- `npm i -d && npm test` → `pnpm install && pnpm test`（pnpm 移行に追従）

## Test plan

- [x] `git diff README.md` で変更内容を目視確認
- [x] 記載した API シグネチャが `index.js` の export と一致